### PR TITLE
use `dir` instead of `directoryPath` when building route types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ export async function autoload(options: IAutoloadOptions = {}) {
 		const imports: string[] = paths.map(
 			(x, index) =>
 				`import type Route${index} from "${(
-					directoryPath + x.replace(".ts", "").replace(".tsx", "")
+					dir + x.replace(".ts", "").replace(".tsx", "")
 				).replace(/\\/gu, "/")}";`,
 		);
 


### PR DESCRIPTION
Closes #12

Untested, but should work