### PR TITLE
Fix type gen for function vs no function exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,7 @@ export async function autoload(options: AutoloadOptions = {}) {
 								`ElysiaWithBaseUrl<"${
 									((prefix?.endsWith("/") ? prefix.slice(0, -1) : prefix) ??
 										"") + transformToUrl(x) || "/"
-								}", ReturnType<typeof Route${index}>>`,
+								}", typeof Route${index}>`,
 						)
 						.join("\n              & ")}`,
 					!types.useExport ? "}" : "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,11 +35,19 @@ type FlattenIndexRoutes<T> = T extends object
       : T)
   : T;
 
+namespace ElysiaMatch {
+  export type Any = Elysia<any, any, any, any, any, any, any, any>;
+  export type Fx = (...args: any[]) => Any;
+  export type All = Any | Fx;
+
+  export type Extract<T extends All> = T extends Fx ? ReturnType<T> : T;
+}
+
 export type ElysiaWithBaseUrl<
   BaseUrl extends string,
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  ElysiaType extends Elysia<any, any, any, any, any, any, any, any>
-> = ElysiaType extends Elysia<
+  ElysiaType extends ElysiaMatch.All
+> = ElysiaMatch.Extract<ElysiaType> extends Elysia<
   infer BasePath,
   infer Scoped,
   infer Singleton,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,38 +10,38 @@ type PathToObject<
     : { [K in Head]: PathToObject<Rest, Type> }
   : { [K in Path]: Type };
 
-type RouteEndType = Record<
-  string,
-  {
-    body: any;
-    params: any;
-    query: any;
-    headers: any;
-    response: any;
-  }
->;
-
-type FlattenIndexRoutes<T> = T extends object
-  ? {
-      [K in keyof T as K extends "index"
-        ? T[K] extends RouteEndType
-          ? never
-          : K
-        : K]: FlattenIndexRoutes<T[K]>;
-    } & (T extends { index: infer I }
-      ? I extends RouteEndType
-        ? FlattenIndexRoutes<I>
-        : T
-      : T)
-  : T;
-
 namespace ElysiaMatch {
+  export type RouteEnd = Record<
+    string,
+    {
+      body: any;
+      params: any;
+      query: any;
+      headers: any;
+      response: any;
+    }
+  >;
+
   export type Any = Elysia<any, any, any, any, any, any, any, any>;
   export type Fx = (...args: any[]) => Any;
   export type All = Any | Fx;
 
   export type Extract<T extends All> = T extends Fx ? ReturnType<T> : T;
 }
+
+type FlattenIndexRoutes<T> = T extends object
+  ? {
+      [K in keyof T as K extends "index"
+        ? T[K] extends ElysiaMatch.RouteEnd
+          ? never
+          : K
+        : K]: FlattenIndexRoutes<T[K]>;
+    } & (T extends { index: infer I }
+      ? I extends ElysiaMatch.RouteEnd
+        ? FlattenIndexRoutes<I>
+        : T
+      : T)
+  : T;
 
 export type ElysiaWithBaseUrl<
   BaseUrl extends string,


### PR DESCRIPTION
I totally forgot about #15 where you added support for `export default new Elysia()` instead of the function stuff
Because of this i fixed the types for ReturnType vs no Function if that makes sense

I tested it so it should work fine