### PR TITLE
fix: remove slash at end of routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ export type ElysiaApp = typeof app;
 // routes/index.ts
 import type { ElysiaApp } from "app";
 
-export default (app: ElysiaApp) => app.get("/", { hello: "world" });
+export default (app: ElysiaApp) => app.get("", { hello: "world" });
 ```
 
 ### Directory structure

--- a/example/routes/exports/default.ts
+++ b/example/routes/exports/default.ts
@@ -1,3 +1,3 @@
 import type { ElysiaApp } from "../../index";
 
-export default (app: ElysiaApp) => app.get("/", { hello: "world" });
+export default (app: ElysiaApp) => app.get("", { hello: "world" });

--- a/example/routes/exports/elysia.ts
+++ b/example/routes/exports/elysia.ts
@@ -1,3 +1,3 @@
 import Elysia from "elysia";
 
-export default new Elysia().get("/", { hello: "world" });
+export default new Elysia().get("", { hello: "world" });

--- a/example/routes/exports/zero-aguments.ts
+++ b/example/routes/exports/zero-aguments.ts
@@ -1,3 +1,3 @@
 import Elysia from "elysia";
 
-export default () => new Elysia().get("/", { hello: "world" });
+export default () => new Elysia().get("", { hello: "world" });

--- a/example/routes/index.ts
+++ b/example/routes/index.ts
@@ -1,4 +1,4 @@
 // routes/index.ts
 import type { ElysiaApp } from "../index";
 
-export default (app: ElysiaApp) => app.get("/", { hello: "world" });
+export default (app: ElysiaApp) => app.get("", { hello: "world" });

--- a/example/routes/test/[some]/index.ts
+++ b/example/routes/test/[some]/index.ts
@@ -4,7 +4,7 @@ import type { ElysiaApp } from "../../../index";
 
 export default (app: ElysiaApp) =>
 	app.get(
-		"/",
+		"",
 		{ hello: "world" },
 		{
 			query: t.Object({


### PR DESCRIPTION
### Elysia use case
```ts
// server.ts
const app = new Elysia()
app.group('/user', (app) => app.get('/test', 'OK'))
console.log('routeTree:', app.routeTree)  // routeTree:  Map(1) { 'GET/user/test' => 0 }
```

### Actual
```ts
// /api/user/test/(get).ts
const get = (app: ElysiaApp) => app.get('/', 'OK')
export default get

// server.ts
const app = new Elysia()
app.use(await autoload({ dir: path.join(import.meta.dirname, './api') }))
console.log('routeTree:', app.routeTree)  // routeTree:  Map(1) { 'GET/user/test/' => 0 }
```

### Expect
```ts
// /api/user/test/(get).ts
const get = (app: ElysiaApp) => app.get('', 'OK')
export default get

// server.ts
const app = new Elysia()
app.use(await autoload({ dir: path.join(import.meta.dirname, './api') }))
console.log('routeTree:', app.routeTree)  // routeTree:  Map(1) { 'GET/user/test' => 0 }
```