### PR TITLE
fix(#24): ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows (Node.js)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
 	type BaseMacro,
 	Elysia,
@@ -134,7 +135,7 @@ export async function autoload(options: AutoloadOptions = {}) {
 	for await (const filePath of sortByNestedParams(files)) {
 		const fullPath = path.join(directoryPath, filePath);
 
-		const file = await import(fullPath);
+		const file = await import(pathToFileURL(fullPath).href);
 
 		const importName =
 			typeof getImportName === "string" ? getImportName : getImportName(file);


### PR DESCRIPTION
Fix #24

### Notes
- [ ] before merge, waiting Node.js support with #23
  - [ ] `pathToFileURL` can be improved and used only when using Node.js: it can be moved at same point of transpile logic added by #23 or used as below:
    ```ts
    // Draft
    typeof Bun === 'undefined' ? await import(pathToFileURL(filePath).href) : await import(filePath)
    ```