### PR TITLE
feat: add ignore option to exclude files from autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ const app = new Elysia().use(await autoload()).listen(3000);
 export type ElysiaApp = typeof app;
 ```
 
+### With custom options
+
+```ts
+import { Elysia } from "elysia";
+import { autoload } from "elysia-autoload";
+
+const app = new Elysia()
+    .use(
+        await autoload({
+            dir: "./routes",
+            prefix: "/api",
+            // Ignore test files and spec files
+            ignore: ["**/*.test.ts", "**/*.spec.ts"]
+        })
+    )
+    .listen(3000);
+
+export type ElysiaApp = typeof app;
+```
+
 > [!IMPORTANT]
 > We strictly recommend use `await` when registering plugin
 >
@@ -99,6 +119,7 @@ Guide how `elysia-autoload` match routes
 | prefix?  | string                                     |                                    | Prefix for routes                                                                   |
 | types?   | boolean \| [Types Options](#types-options) | false                              | Options to configure type code-generation. if boolean - enables/disables generation |
 | schema?  | Function                                   |                                    | Handler for providing routes guard schema                                           |
+| ignore?  | string \| string[]                         |                                    | Glob pattern(s) to ignore when discovering files                                    |
 
 ### Types Options
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { edenFetch } from "@elysiajs/eden";
 import { Elysia } from "elysia";
 import { autoload } from "../src/index";
-import { sortByNestedParams, transformToUrl } from "../src/utils";
+import { matchesPattern, sortByNestedParams, transformToUrl } from "../src/utils";
 
 // const app_with_prefix = new Elysia({
 // 	prefix: "/api", // BROKEN FOR NOW
@@ -89,6 +89,44 @@ describe("sortByNestedParams", () => {
 
     test("Verify Intellisense", () => {
         // const request = fetcher("", {});
+    });
+});
+
+describe("matchesPattern", () => {
+    test("matches exact filename", () => {
+        expect(matchesPattern("test.ts", "test.ts")).toBe(true);
+        expect(matchesPattern("test.ts", "other.ts")).toBe(false);
+    });
+
+    test("matches wildcard patterns", () => {
+        expect(matchesPattern("test.ts", "*.ts")).toBe(true);
+        expect(matchesPattern("test.js", "*.ts")).toBe(false);
+        expect(matchesPattern("path/to/test.ts", "**/test.ts")).toBe(true);
+        expect(matchesPattern("path/to/file.ts", "**/*.ts")).toBe(true);
+    });
+
+    test("matches glob patterns with directories", () => {
+        expect(matchesPattern("src/test.ts", "src/*.ts")).toBe(true);
+        expect(matchesPattern("src/nested/test.ts", "src/*.ts")).toBe(false);
+        expect(matchesPattern("src/nested/test.ts", "src/**/*.ts")).toBe(true);
+    });
+
+    test("matches patterns with extensions", () => {
+        expect(matchesPattern("test.spec.ts", "*.spec.ts")).toBe(true);
+        expect(matchesPattern("test.test.ts", "*.test.ts")).toBe(true);
+        expect(matchesPattern("test.spec.ts", "*.test.ts")).toBe(false);
+    });
+
+    test("matches patterns with multiple extensions", () => {
+        expect(matchesPattern("test.ts", "*.{ts,js}")).toBe(true);
+        expect(matchesPattern("test.js", "*.{ts,js}")).toBe(true);
+        expect(matchesPattern("test.py", "*.{ts,js}")).toBe(false);
+    });
+
+    test("matches nested wildcard patterns", () => {
+        expect(matchesPattern("src/components/Button.test.ts", "**/*.test.ts")).toBe(true);
+        expect(matchesPattern("src/components/Button.spec.ts", "**/*.spec.ts")).toBe(true);
+        expect(matchesPattern("src/components/Button.ts", "**/*.test.ts")).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary
- Adds a new `ignore` option to the autoload configuration
- Allows users to exclude files from being autoloaded using glob patterns
- Supports both single string and array of strings for multiple ignore patterns

## Motivation
This library uses Bun's glob functionality (`Bun.Glob`), but Bun.Glob does not currently support ignoring files natively (see https://github.com/oven-sh/bun/issues/8182). This feature adds ignore functionality at the application level to work around this limitation.

## Changes
- Added `ignore?: string | string[]` option to `AutoloadOptions` interface
- Implemented `matchesPattern` utility function for cross-platform glob matching (supports both Bun and Node.js)
- Added filtering logic in the main autoload function to exclude files matching ignore patterns
- Added comprehensive tests for the pattern matching functionality
- Updated README with documentation and examples for the new option

## Use Cases
This feature is particularly useful for:
- Excluding test files (`**/*.test.ts`, `**/*.spec.ts`)
- Ignoring documentation or example files
- Excluding files that shouldn't be exposed as routes but need to be in the routes directory

## Example Usage
```typescript
await autoload({
    dir: "./routes",
    prefix: "/api",
    // Ignore test files and spec files
    ignore: ["**/*.test.ts", "**/*.spec.ts"]
})
```

## Testing
Added comprehensive tests covering:
- Exact filename matching
- Wildcard patterns
- Directory patterns  
- Multiple extensions
- Nested wildcards

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.ai/code)